### PR TITLE
chore: use latest pages artifact upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,9 +33,10 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
+          name: github-pages
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- ensure GitHub Pages workflow uploads the build using actions/upload-pages-artifact@v4

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `@typescript-eslint/no-empty-object-type`, `@typescript-eslint/no-require-imports`)
- `npm run build`
- `./bin/act -j build` (fails: no Docker connection)


------
https://chatgpt.com/codex/tasks/task_e_68c7c391cd3c8321a6b314c27a84a9f9