### PR TITLE
Configure Vite base path via environment variable

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,8 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  // Use repository subpath for GitHub Pages in production
-  base: mode === "development" ? "/" : "/garden-bloom-paarl/",
+  // Configure base path via environment variable for deployment flexibility
+  base: process.env.VITE_BASE_PATH || "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure Vite `base` option to read from `VITE_BASE_PATH` env var, defaulting to root

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c807574083219e105245fad624d1